### PR TITLE
Bugfix/remote exit codes

### DIFF
--- a/src/nimbo/core/execute.py
+++ b/src/nimbo/core/execute.py
@@ -175,11 +175,13 @@ def run_remote_script(ssh_cmd, scp_cmd, host, instance_id, job_cmd, script, conf
             f"nohup {bash_cmd} {instance_id} {job_cmd} </dev/null >{NIMBO_LOG} 2>&1 &"
         )
     else:
-        full_command = f"{bash_cmd} {instance_id} {job_cmd} | tee {NIMBO_LOG}"
+        full_command = f"{bash_cmd} {instance_id} {job_cmd} >{NIMBO_LOG} 2>&1"
 
-    stdout, stderr = subprocess.Popen(
+    child = subprocess.Popen(
         f'{ssh_cmd} ubuntu@{host} "{full_command}"', shell=True
-    ).communicate()
+    )
+    child.communicate()
+    return child.returncode
 
 
 def run_job(session, config, job_cmd, dry_run=False):

--- a/src/nimbo/core/execute.py
+++ b/src/nimbo/core/execute.py
@@ -41,6 +41,7 @@ def launch_instance(client, config):
         "KeyName": config["instance_key"],
         "Placement": {"Tenancy": "default"},
         "SecurityGroups": [config["security_group"]],
+        "InstanceInitiatedShutdownBehavior": "terminate",
         "IamInstanceProfile": {"Name": "NimboInstanceProfile"},
     }
 

--- a/src/nimbo/core/execute.py
+++ b/src/nimbo/core/execute.py
@@ -265,7 +265,7 @@ def run_job(session, config, job_cmd, dry_run=False):
 def run_access_test(session, config, dry_run=False):
     if dry_run:
         return
-    config["instance_type"] = "t3.medium"
+    config["instance_type"] = "t3a.nano"
     config["run_in_background"] = False
     config["persist"] = False
 


### PR DESCRIPTION
I noticed that run_remote_script did not propagate the remote script's exit code, so that has been changed.

I also noted that when running in foreground mode, the command is executed with `tee` as the last process in the pipeline:
`command | tee logfile` which means that the final exit code of the process will be that of tee, which is basically always 0. I removed tee, to be able to get the exit code from the actual script.

I also added explicit instance configuration for termination on exit. I also changed to a cheaper instance type for running the test.