### PR TITLE
Add development shell flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,108 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1619614179,
+        "narHash": "sha256-cf7RsJwnqiVi6hnDZCTHwGxEfvdI7NcV1vxvxrMCfPM=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "a7ddac2ce8942421fdb26207b5f69f9fa85de69f",
+        "type": "github"
+      },
+      "original": {
+        "id": "mach-nix",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1615259932,
+        "narHash": "sha256-IXecmbqCr+XCtFwzBO3tHEd8PoJ4X4EyPZebKbV2ioE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "29b0d4d0b600f8f5dd0b86e3362a33d4181938f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1619790734,
+        "narHash": "sha256-ZTNxPO9xWLt0kviYRCNt2TwbpXDPxvHTmIDh+DINUPo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c89bf4519524a2cc428b7da12d64cb1f76503335",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1615363940,
+        "narHash": "sha256-GJ3ONLWAr5ejqR5bKVfKpI/n+ClaxjyYewMP+QJyq5M=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "ab522f2d3255789f1ef97fa7c83d4342be156e67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,4 @@
-
+{
   description = "Nimbo development shell";
   nixConfig.bash-prompt = "[nimbo-dev-shell]$ ";
   inputs = { flake-utils.url = "github:numtide/flake-utils"; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  inputs = {
+    mach-nix.url = "github:DavHau/mach-nix?rev=3.2.0";
+  };
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
+  let pkgs = nixpkgs.legacyPackages.${system};
+  {
+    devShell = pkgs.mkShell {
+    };
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,24 @@
-{
-  inputs = {
-    mach-nix.url = "github:DavHau/mach-nix?rev=3.2.0";
-  };
-  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
-  let pkgs = nixpkgs.legacyPackages.${system};
-  {
-    devShell = pkgs.mkShell {
-    };
-  });
+
+  description = "Nimbo development shell";
+  nixConfig.bash-prompt = "[nimbo-dev-shell]$ ";
+  inputs = { flake-utils.url = "github:numtide/flake-utils"; };
+  outputs = { self, nixpkgs, flake-utils, mach-nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs;
+            with python3Packages; [
+              python3
+
+              awscli
+              boto3
+              click
+              pydantic
+              pyyaml
+              requests
+              setuptools
+            ];
+        };
+      });
 }


### PR DESCRIPTION
I've written a really simple nix-flake expression to create a development shell that _should_ have all the dependencies required for testing.
I'm happy to rewrite this as a regular nix expression as nix flakes are [currently](https://nixos.wiki/wiki/Flakes) in beta and have to be enable manually --- but I think they're really cool.

Feedback appreciated.

EDIT:
Steps to actually use this:
1. Enable nix flakes (if you haven't already), by following [this](https://nixos.wiki/wiki/Flakes#Installing_flakes)
2. Enter the root directory of the project
3. Run `nix develop`

The shell provisionally reads `[nimbo-dev-shell] $` to make it play nicely with both zsh and bash, but that's more cosmetic and can be changed to whatever, or removed totally to preserve the user's original shell, but I find it useful to help me remember which shell I'm in 😅.