### PR TITLE
config: add basic provisional support for env vars

### DIFF
--- a/src/nimbo/core/config.py
+++ b/src/nimbo/core/config.py
@@ -244,8 +244,11 @@ class NimboConfig(pydantic.BaseModel):
 def load_yaml_from_file(file: str) -> Dict[str, Any]:
     if os.path.isfile(file):
         with open(file, "r") as f:
-            return yaml.safe_load(f)
-
+            config_yaml = yaml.safe_load(f)
+        for key, val in config_yaml.items():
+            if isinstance(val, str) and val.startswith("$"):
+                config_yaml[key] = os.environ.get(val[1:])
+        return config_yaml
     return {}
 
 


### PR DESCRIPTION
Allows the user to specify environment variables in yaml and have them be sourced at runtime.

I can think of a nice functional way of doing this, but this way feels more pythonic. It's really basic but I can't get it to break.

Only known issue is that if you set a variable to an unset env var, the error produced reads:
```
For running this command instance_key should be specified in nimbo-config.yml
```
Which isn't descriptive to the new error, but we'd need to decide how to handle missing environment vars first, as currently they go in as `None` values.