### PR TITLE
Allow specification of env vars in Nimbo config

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,16 +1,16 @@
 -i https://pypi.org/simple
 appdirs==1.4.4
-attrs==20.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-awscli==1.19.62
-black==21.4b2
-boto3==1.17.62
-botocore==1.20.62
+attrs==21.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+awscli==1.19.82
+black==21.5b1
+boto3==1.17.82
+botocore==1.20.82
 cachecontrol==0.12.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 cachetools==4.2.2; python_version ~= '3.5'
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-click==7.1.2
+click==8.0.1
 colorama==0.4.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 commonmark==0.9.1
 dependency==0.0.3
@@ -18,17 +18,17 @@ distlib==0.3.1
 docutils==0.15.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 filelock==3.0.12
 firebase-admin==5.0.0
-google-api-core[grpc]==1.26.3; platform_python_implementation != 'PyPy'
-google-api-python-client==2.3.0; python_version >= '3.6'
+google-api-core[grpc]==1.28.0; platform_python_implementation != 'PyPy'
+google-api-python-client==2.6.0; python_version >= '3.6'
 google-auth-httplib2==0.1.0
-google-auth==1.30.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+google-auth==1.30.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 google-cloud-core==1.6.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-google-cloud-firestore==2.1.0; platform_python_implementation != 'PyPy'
+google-cloud-firestore==2.1.1; platform_python_implementation != 'PyPy'
 google-cloud-storage==1.38.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 google-crc32c==1.1.2; python_version >= '3.5'
-google-resumable-media==1.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+google-resumable-media==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 googleapis-common-protos==1.53.0; python_version >= '3.6'
-grpcio==1.37.1
+grpcio==1.38.0
 httplib2==0.19.1
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 iniconfig==1.1.1
@@ -39,28 +39,28 @@ packaging==20.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.
 pathspec==0.8.1
 pluggy==0.13.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 proto-plus==1.18.1; python_version >= '3.6'
-protobuf==3.15.8
+protobuf==3.17.1
 py==1.10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pydantic==1.8.1
-pygments==2.8.1; python_version >= '3.5'
+pydantic==1.8.2
+pygments==2.9.0; python_version >= '3.5'
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pytest-env==0.6.2
-pytest==6.2.3
+pytest==6.2.4
 python-dateutil==2.8.1
 pytz==2021.1
-pyyaml==5.4.1
+pyyaml==5.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 regex==2021.4.4
 requests==2.25.1
-rich==10.1.0
+rich==10.2.2
 rsa==4.7.2; python_version > '2.7'
 s3transfer==0.4.2
-six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-tox==3.23.0
+tox==3.23.1
 typing-extensions==3.10.0.0
 uritemplate==3.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-urllib3==1.26.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
-virtualenv==20.4.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+urllib3==1.26.5; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+virtualenv==20.4.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -1,10 +1,10 @@
 -i https://pypi.org/simple
-awscli==1.19.62
-boto3==1.17.62
-botocore==1.20.62
+awscli==1.19.82
+boto3==1.17.82
+botocore==1.20.82
 certifi==2020.12.5
 chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-click==7.1.2
+click==8.0.1
 colorama==0.4.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 commonmark==0.9.1
 dependency==0.0.3
@@ -12,14 +12,14 @@ docutils==0.15.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 jmespath==0.10.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyasn1==0.4.8
-pydantic==1.8.1
-pygments==2.8.1; python_version >= '3.5'
+pydantic==1.8.2
+pygments==2.9.0; python_version >= '3.5'
 python-dateutil==2.8.1
-pyyaml==5.4.1
+pyyaml==5.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 requests==2.25.1
-rich==10.1.0
+rich==10.2.2
 rsa==4.7.2; python_version > '2.7'
 s3transfer==0.4.2
-six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 typing-extensions==3.10.0.0
-urllib3==1.26.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.5; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'

--- a/src/nimbo/__init__.py
+++ b/src/nimbo/__init__.py
@@ -16,7 +16,6 @@ try:
         CONFIG = nimbo.tests.aws.config.make_config()
     else:
         CONFIG = nimbo.core.config.make_config()
-
 except pydantic.error_wrappers.ValidationError as e:
     e_msg = str(e)
     e_num = len(e.errors())

--- a/src/nimbo/core/cloud_provider/__init__.py
+++ b/src/nimbo/core/cloud_provider/__init__.py
@@ -1,7 +1,7 @@
 from nimbo import CONFIG
 from nimbo.core.cloud_provider.provider_impl.aws.aws_provider import AwsProvider
 from nimbo.core.cloud_provider.provider_impl.gcp.gcp_provider import GcpProvider
-from nimbo.core.config.common import CloudProvider
+from nimbo.core.config.common_config import CloudProvider
 
 if CONFIG.cloud_provider == CloudProvider.AWS:
     Cloud = AwsProvider()

--- a/src/nimbo/core/config/__init__.py
+++ b/src/nimbo/core/config/__init__.py
@@ -3,15 +3,16 @@ from typing import Union
 import pydantic
 
 from nimbo.core.config.aws_config import AwsConfig
-from nimbo.core.config.common import CloudProvider, load_yaml_from_file
-from nimbo.core.config.common import RequiredCase
+import nimbo.core.config.yaml_loader
+from nimbo.core.config.common_config import CloudProvider
+from nimbo.core.config.common_config import RequiredCase
 from nimbo.core.config.gcp_config import GcpConfig
 from nimbo.core.constants import NIMBO_CONFIG_FILE
 
 
 # noinspection PyUnresolvedReferences
 def make_config() -> Union[AwsConfig, GcpConfig]:
-    config = load_yaml_from_file(NIMBO_CONFIG_FILE)
+    config = yaml_loader.from_file(NIMBO_CONFIG_FILE)
 
     # Provider field validation is postponed. If cloud_provider is not specified,
     # assume AwsConfig for running commands like --help and generate-config.

--- a/src/nimbo/core/config/aws_config.py
+++ b/src/nimbo/core/config/aws_config.py
@@ -8,7 +8,7 @@ import botocore
 import botocore.session
 import pydantic
 
-from nimbo.core.config.common import BaseConfig, RequiredCase
+from nimbo.core.config.common_config import BaseConfig, RequiredCase
 from nimbo.core.constants import FULL_REGION_NAMES, NIMBO_CONFIG_FILE
 
 

--- a/src/nimbo/core/config/common_config.py
+++ b/src/nimbo/core/config/common_config.py
@@ -1,9 +1,8 @@
 import enum
 import os
-from typing import Any, Dict, Optional, Set
+from typing import Optional, Set
 
 import pydantic
-import yaml
 
 from nimbo.core.constants import NIMBO_CONFIG_FILE, TELEMETRY_URL
 
@@ -84,11 +83,3 @@ class BaseConfig(pydantic.BaseModel):
         if value != TELEMETRY_URL:
             raise ValueError("overriding telemetry url is forbidden")
         return value
-
-
-def load_yaml_from_file(file: str) -> Dict[str, Any]:
-    if os.path.isfile(file):
-        with open(file, "r") as f:
-            return yaml.safe_load(f)
-
-    return {}

--- a/src/nimbo/core/config/gcp_config.py
+++ b/src/nimbo/core/config/gcp_config.py
@@ -1,4 +1,4 @@
-from nimbo.core.config.common import BaseConfig
+from nimbo.core.config.common_config import BaseConfig
 
 
 class GcpConfig(BaseConfig):

--- a/src/nimbo/core/config/yaml_loader.py
+++ b/src/nimbo/core/config/yaml_loader.py
@@ -56,15 +56,15 @@ def _substitute_env_vars(key: str, value: str) -> str:
 
 def from_file(file: str) -> Dict[str, Any]:
     """ Load YAML into a dictionary, inject environment variables """
+    
+    if os.path.isfile(file):
+        with open(file, "r") as f:
+            config = yaml.safe_load(f)
 
-    if not os.path.isfile(file):
-        raise FileNotFoundError(f"{file} is not a file")
+        for key, value in config.items():
+            if type(value) == str and "${" in value:
+                config[key] = _substitute_env_vars(key, value)
 
-    with open(file, "r") as f:
-        config = yaml.safe_load(f)
-
-    for key, value in config.items():
-        if type(value) == str and "${" in value:
-            config[key] = _substitute_env_vars(key, value)
-
-    return config
+        return config
+    
+    return {}

--- a/src/nimbo/core/config/yaml_loader.py
+++ b/src/nimbo/core/config/yaml_loader.py
@@ -1,0 +1,70 @@
+import os
+import re
+from typing import Any, Dict
+
+import pydantic
+import yaml
+
+# pattern for extracting env variables
+from nimbo.core.config.common_config import BaseConfig
+
+RE_PATTERN = re.compile(
+    r"(\$(?:{(?P<env>(.*?))(\|(?P<env_default>.*?))?}))",
+    re.MULTILINE | re.UNICODE | re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _substitute_env_vars(key: str, value: str) -> str:
+    """
+    Take in a string optionally containing "${ENV_VARIABLE|optional-default}"
+    and return a new string with substituted environment variables
+    """
+
+    replacements = []
+
+    for env_var in RE_PATTERN.finditer(value):
+        groups = env_var.groupdict()
+        variable, default = groups["env"], groups["env_default"]
+
+        to_replace = "${" + variable
+        to_replace += "|" + default if default else ""
+        to_replace += "}"
+
+        replace_with = default
+        try:
+            replace_with = os.environ[variable]
+        except KeyError:
+            if not replace_with:
+                raise pydantic.ValidationError(
+                    [
+                        pydantic.error_wrappers.ErrorWrapper(
+                            Exception(f"Environment variable {variable} not defined"),
+                            key,
+                        )
+                    ],
+                    BaseConfig,
+                )
+
+        replacements.append([to_replace, replace_with])
+
+    if replacements:
+        for to_replace, replace_with in replacements:
+            value = value.replace(to_replace, replace_with)
+
+    return value
+
+
+def from_file(file: str) -> Dict[str, Any]:
+    """ Load YAML into a dictionary, inject environment variables """
+
+    if not os.path.isfile(file):
+        raise FileNotFoundError(f"{file} is not a file")
+
+    with open(file, "r") as f:
+        config = yaml.safe_load(f)
+
+    for key, value in config.items():
+        if type(value) == str and "${" in value:
+            config[key] = _substitute_env_vars(key, value)
+
+    return config

--- a/src/nimbo/tests/aws/config.py
+++ b/src/nimbo/tests/aws/config.py
@@ -11,7 +11,7 @@ from nimbo.core.config import (
     CloudProvider,
     GcpConfig,
     RequiredCase,
-    load_yaml_from_file,
+    yaml_loader,
 )
 
 NIMBO_CONFIG_FILE = "nimbo-config.yml"
@@ -95,7 +95,7 @@ class GcpTestConfig(CommonTestConfigMixin, GcpConfig):
 
 
 def make_config() -> Union[AwsTestConfig, GcpTestConfig]:
-    raw_config = load_yaml_from_file(os.path.join(ASSETS_PATH, NIMBO_CONFIG_FILE))
+    raw_config = yaml_loader.from_file(os.path.join(ASSETS_PATH, NIMBO_CONFIG_FILE))
     cloud_provider = CloudProvider(raw_config["cloud_provider"].upper())
 
     if cloud_provider == CloudProvider.AWS:


### PR DESCRIPTION
Implements feature requested in https://github.com/nimbo-sh/nimbo/issues/5

This change allows the specification of env vars in Nimbo config in the form `${ENV_VARIABLE}`, supports default values in the form `${ENV_VARIABLE|default}`.
```
cloud_provider: AWS

local_datasets_path: data
local_results_path: results
s3_datasets_path: s3://nimbo-juozas/nimbo-test/in
s3_results_path: s3://nimbo-juozas/nimbo-test/out

# Test integers
aws_profile: default
region_name: eu-west-1
instance_type: t3.medium

image: ubuntu18-latest-drivers
disk_size: ${DISK_SIZE|128}
conda_env: nimbus.yml

run_in_background: no
persist: no

security_group: organisation-${USER_ID}-postfix
instance_key: eu-west-1-juozas.pem
role: NimboFullS3AccessRole
```