### PR TITLE
Allow to specify config file via CLI option or env var

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             NimboSH, Ltd.
-Licensed Work:        Nimbo 0.3.0
+Licensed Work:        Nimbo 0.3.1
                       The Licensed Work is (c) 2021 NimboSH, Ltd.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Cloud Automation

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setuptools.setup(
         "boto3>=1.17",
         "awscli>=1.19<2.0",
         "rich>=10.1.0",
-        "python-dateutil>=2.8.0"
+        "python-dateutil>=2.8.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="nimbo",  # Replace with your own username
-    version="0.3.0",
+    version="0.3.1",
     author="NimboSH, Ltd.",
     author_email="support@nimbo.sh",
     description="Run machine learning jobs on AWS with a single command.",

--- a/src/nimbo/__init__.py
+++ b/src/nimbo/__init__.py
@@ -1,25 +1,89 @@
+import functools
 import re
 import sys
+import typing as t
 
 import pkg_resources
 import pydantic
 
 import nimbo.core.config
 import nimbo.tests.aws.config
+from nimbo.core.config import RequiredCase
+from nimbo.core.config.aws_config import AwsConfig
+from nimbo.core.config.common_config import CloudProvider
+from nimbo.core.config.gcp_config import GcpConfig
 from nimbo.core.constants import IS_TEST_ENV
+from nimbo.core.print import nprint
 
 version = pkg_resources.get_distribution("nimbo").version
 
 
-try:
-    if IS_TEST_ENV:
-        CONFIG = nimbo.tests.aws.config.make_config()
+CONFIG: t.Optional[t.Union[AwsConfig, GcpConfig]] = None
+_CLOUD = None
+
+
+def set_config(config_factory, config_path):
+    global CONFIG, _CLOUD
+
+    try:
+        CONFIG = config_factory(config_path)
+    except pydantic.error_wrappers.ValidationError as e:
+        e_msg = str(e)
+        e_num = len(e.errors())
+        title_end = e_msg.index("\n", 1)
+        new_title = (
+            f"{e_num} error{'' if e_num == 1 else 's'} in "
+            f"{config_path if config_path else 'nimbo-config.yml'}\n"
+        )
+        print(new_title + re.sub(r"\(type=.*\)", "", e_msg[title_end:]))
+        sys.exit(1)
+
+    # Both of these imports depend on this file
+    from nimbo.core.cloud_provider.provider_impl.aws.aws_provider import AwsProvider
+    from nimbo.core.cloud_provider.provider_impl.gcp.gcp_provider import GcpProvider
+
+    if CONFIG.cloud_provider == CloudProvider.AWS:
+        _CLOUD = AwsProvider()
     else:
-        CONFIG = nimbo.core.config.make_config()
-except pydantic.error_wrappers.ValidationError as e:
-    e_msg = str(e)
-    e_num = len(e.errors())
-    title_end = e_msg.index("\n", 1)
-    new_title = f"{e_num} error{'' if e_num == 1 else 's'} in nimbo-config.yml\n"
-    print(new_title + re.sub(r"\(type=.*\)", "", e_msg[title_end:]))
-    sys.exit(1)
+        _CLOUD = GcpProvider()
+
+
+if IS_TEST_ENV:
+    set_config(nimbo.tests.aws.config.make_config, "nimbo-config.yml")
+
+
+def assert_required_config(*cases: RequiredCase):
+    """
+    Decorator for ensuring that required config is present
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def decorated(*args, **kwargs):
+            try:
+                CONFIG.assert_required_config_exists(*cases)
+                return func(*args, **kwargs)
+            except AssertionError as e:
+                nprint(e, style="error")
+                sys.exit(1)
+            except FileNotFoundError as e:
+                # Happens when nimbo config file is not found
+                nprint(e, style="error")
+                sys.exit(1)
+
+        return decorated
+
+    return decorator
+
+
+def cloud_context(func):
+    """
+    Decorator for injecting a key-value argument cloud of type AwsProvider|GcpProvider
+    """
+
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        kwargs["cloud"] = _CLOUD
+        return func(*args, **kwargs)
+
+    return decorated

--- a/src/nimbo/core/cloud_provider/__init__.py
+++ b/src/nimbo/core/cloud_provider/__init__.py
@@ -1,9 +1,0 @@
-from nimbo import CONFIG
-from nimbo.core.cloud_provider.provider_impl.aws.aws_provider import AwsProvider
-from nimbo.core.cloud_provider.provider_impl.gcp.gcp_provider import GcpProvider
-from nimbo.core.config.common_config import CloudProvider
-
-if CONFIG.cloud_provider == CloudProvider.AWS:
-    Cloud = AwsProvider()
-else:
-    Cloud = GcpProvider()

--- a/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_instance.py
+++ b/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_instance.py
@@ -70,7 +70,7 @@ class AwsInstance(Instance):
             # Create project folder and send env and config files there
             subprocess.check_output(f"{ssh} ubuntu@{host} mkdir project", shell=True)
             subprocess.check_output(
-                f"{scp} {local_env} {CONFIG.nimbo_config_file} {NIMBO_VARS}"
+                f"{scp} {local_env} {CONFIG.config_path} {NIMBO_VARS}"
                 f" ubuntu@{host}:/home/ubuntu/project/",
                 shell=True,
             )
@@ -136,9 +136,7 @@ class AwsInstance(Instance):
             )
             subprocess.check_output(command, shell=True)
 
-            command = (
-                f"aws s3 ls {results_path} --profile {profile} --region {region}"
-            )
+            command = f"aws s3 ls {results_path} --profile {profile} --region {region}"
             subprocess.check_output(command, shell=True)
             command = (
                 f"aws s3 rm {results_path}/nimbo-access-test.txt "
@@ -191,7 +189,7 @@ class AwsInstance(Instance):
             AwsInstance._write_nimbo_vars()
 
             subprocess.check_output(
-                f"{scp} {CONFIG.nimbo_config_file} {NIMBO_VARS} "
+                f"{scp} {CONFIG.config_path} {NIMBO_VARS} "
                 + f"ubuntu@{host}:/home/ubuntu/",
                 shell=True,
             )
@@ -347,7 +345,8 @@ class AwsInstance(Instance):
                 while status != "fulfilled":
                     time.sleep(2)
                     response = ec2.describe_spot_instance_requests(
-                        SpotInstanceRequestIds=[request_id], Filters=instance_filters,
+                        SpotInstanceRequestIds=[request_id],
+                        Filters=instance_filters,
                     )
                     instance_request = response["SpotInstanceRequests"][0]
                     status = instance_request["Status"]["Code"]
@@ -364,7 +363,8 @@ class AwsInstance(Instance):
 
             nprint_header("Done.")
             ec2.create_tags(
-                Resources=[instance_request["InstanceId"]], Tags=instance_tags,
+                Resources=[instance_request["InstanceId"]],
+                Tags=instance_tags,
             )
             instance = instance_request
         else:

--- a/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_permissions.py
+++ b/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_permissions.py
@@ -1,7 +1,6 @@
 import json
 import os
 import sys
-from typing import Optional
 
 import boto3
 import botocore.exceptions
@@ -115,7 +114,7 @@ class AwsPermissions(Permissions):
                 " and instance role,\nwe recommend that you create a role with the"
                 " necessary S3 permissions in the AWS console.\nOnce you do this, give"
                 " the role name to the people using Nimbo so that they can set\n"
-                "the 'role' field in the nimbo-config.yml to this value.",
+                "the 'role' field in the configuration file to this value.",
                 style="warning",
             )
         else:

--- a/src/nimbo/core/config/__init__.py
+++ b/src/nimbo/core/config/__init__.py
@@ -1,18 +1,18 @@
-from typing import Union
+import typing as t
 
 import pydantic
 
-from nimbo.core.config.aws_config import AwsConfig
 import nimbo.core.config.yaml_loader
+from nimbo.core.config.aws_config import AwsConfig
 from nimbo.core.config.common_config import CloudProvider
 from nimbo.core.config.common_config import RequiredCase
 from nimbo.core.config.gcp_config import GcpConfig
-from nimbo.core.constants import NIMBO_CONFIG_FILE
 
 
 # noinspection PyUnresolvedReferences
-def make_config() -> Union[AwsConfig, GcpConfig]:
-    config = yaml_loader.from_file(NIMBO_CONFIG_FILE)
+def make_config(config_path: str) -> t.Union[AwsConfig, GcpConfig]:
+    config = yaml_loader.from_file(config_path)
+    config["config_path"] = config_path
 
     # Provider field validation is postponed. If cloud_provider is not specified,
     # assume AwsConfig for running commands like --help and generate-config.

--- a/src/nimbo/core/config/aws_config.py
+++ b/src/nimbo/core/config/aws_config.py
@@ -9,7 +9,7 @@ import botocore.session
 import pydantic
 
 from nimbo.core.config.common_config import BaseConfig, RequiredCase
-from nimbo.core.constants import FULL_REGION_NAMES, NIMBO_CONFIG_FILE
+from nimbo.core.constants import FULL_REGION_NAMES
 
 
 class _DiskType(str, enum.Enum):
@@ -67,9 +67,9 @@ class AwsConfig(BaseConfig):
 
         if len(cases) == 1 and RequiredCase.NONE in cases:
             return
-        elif not self._nimbo_config_file_exists:
+        elif not os.path.isfile(self.config_path):
             raise FileNotFoundError(
-                f"Nimbo configuration file '{self.nimbo_config_file}' not found.\n"
+                f"Nimbo configuration file '{self.config_path}' not found.\n"
                 "Run 'nimbo generate-config' to create the default config file."
             )
 
@@ -97,7 +97,7 @@ class AwsConfig(BaseConfig):
         if unspecified:
             raise AssertionError(
                 f"For running this command '{', '.join(unspecified)}' should"
-                f" be specified in {self.nimbo_config_file}"
+                f" be specified in {self.config_path}"
             )
 
         bad_fields = {}
@@ -121,7 +121,7 @@ class AwsConfig(BaseConfig):
         if bad_fields:
             print(
                 f"{len(bad_fields)} error{'' if len(bad_fields) == 1 else 's'} "
-                f"in {NIMBO_CONFIG_FILE}\n"
+                f"in {self.config_path}\n"
             )
             for key, error in bad_fields:
                 print(key)

--- a/src/nimbo/core/config/common_config.py
+++ b/src/nimbo/core/config/common_config.py
@@ -4,7 +4,7 @@ from typing import Optional, Set
 
 import pydantic
 
-from nimbo.core.constants import NIMBO_CONFIG_FILE, TELEMETRY_URL
+from nimbo.core.constants import TELEMETRY_URL
 
 
 class RequiredCase(str, enum.Enum):
@@ -40,6 +40,7 @@ class BaseConfig(pydantic.BaseModel):
         title = "Nimbo configuration"
         extra = "forbid"
 
+    config_path: str
     cloud_provider: CloudProvider = None
 
     local_datasets_path: Optional[str] = None
@@ -53,12 +54,7 @@ class BaseConfig(pydantic.BaseModel):
     ssh_timeout: pydantic.conint(strict=True, ge=0) = 180
     telemetry: bool = True
 
-    # The following are defined internally
-    nimbo_config_file: str = NIMBO_CONFIG_FILE
     user_id: Optional[str] = None
-    _nimbo_config_file_exists: bool = pydantic.PrivateAttr(
-        default=os.path.isfile(NIMBO_CONFIG_FILE)
-    )
     telemetry_url: str = TELEMETRY_URL
 
     def _local_results_not_outside_project(self) -> Optional[str]:
@@ -72,12 +68,6 @@ class BaseConfig(pydantic.BaseModel):
             return "local_datasets_path should be a relative path"
         if ".." in self.local_datasets_path:
             return "local_datasets_path should not be outside of the project directory"
-
-    @pydantic.validator("nimbo_config_file")
-    def _nimbo_config_file_unchanged(cls, value):
-        if value != NIMBO_CONFIG_FILE:
-            raise ValueError("overriding nimbo config file name is forbidden")
-        return value
 
     @pydantic.validator("telemetry_url")
     def _nimbo_telemetry_url_unchanged(cls, value):

--- a/src/nimbo/core/config/yaml_loader.py
+++ b/src/nimbo/core/config/yaml_loader.py
@@ -56,7 +56,7 @@ def _substitute_env_vars(key: str, value: str) -> str:
 
 def from_file(file: str) -> Dict[str, Any]:
     """ Load YAML into a dictionary, inject environment variables """
-    
+
     if os.path.isfile(file):
         with open(file, "r") as f:
             config = yaml.safe_load(f)
@@ -66,5 +66,5 @@ def from_file(file: str) -> Dict[str, Any]:
                 config[key] = _substitute_env_vars(key, value)
 
         return config
-    
+
     return {}

--- a/src/nimbo/core/constants.py
+++ b/src/nimbo/core/constants.py
@@ -4,7 +4,6 @@ import pathlib
 IS_TEST_ENV = "NIMBO_ENV" in os.environ and os.environ["NIMBO_ENV"] == "test"
 
 NIMBO_ROOT = str(pathlib.Path(__file__).parent.parent.absolute())
-NIMBO_CONFIG_FILE = "nimbo-config.yml"
 NIMBO_VARS = "/tmp/nimbo_vars"
 TELEMETRY_URL = "https://nimbotelemetry-8ef4c-default-rtdb.firebaseio.com/events.json"
 

--- a/src/nimbo/core/utils.py
+++ b/src/nimbo/core/utils.py
@@ -1,83 +1,22 @@
-import functools
 import os
-import sys
 
-import botocore
-import botocore.errorfactory
 import click
 
-from nimbo import CONFIG
-from nimbo.core.config import RequiredCase
-from nimbo.core.constants import (
-    IS_TEST_ENV,
-    NIMBO_DEFAULT_CONFIG,
-)
-from nimbo.core.print import nprint
+from nimbo.core.constants import NIMBO_DEFAULT_CONFIG
 
 
-def assert_required_config(*cases: RequiredCase):
-    """
-    Decorator for ensuring that required config is present
-    """
-
-    def decorator(func):
-        @functools.wraps(func)
-        def decorated(*args, **kwargs):
-            try:
-                CONFIG.assert_required_config_exists(*cases)
-                return func(*args, **kwargs)
-            except AssertionError as e:
-                nprint(e, style="error")
-                sys.exit(1)
-            except FileNotFoundError as e:
-                # Happens when nimbo config file is not found
-                nprint(e, style="error")
-                sys.exit(1)
-
-        return decorated
-
-    return decorator
-
-
-def handle_errors(func):
-    """
-    Decorator for catching boto3 ClientErrors, ValueError or KeyboardInterrupts.
-    In case of error print the error message and stop Nimbo.
-    """
-
-    @functools.wraps(func)
-    def decorated(*args, **kwargs):
-        if IS_TEST_ENV:
-            return func(*args, **kwargs)
-        else:
-            try:
-                return func(*args, **kwargs)
-            except botocore.errorfactory.ClientError as e:
-                nprint(e, style="error")
-                sys.exit(1)
-            except ValueError as e:
-                nprint(e, style="error")
-                sys.exit(1)
-            except KeyboardInterrupt:
-                print("Aborting...")
-                sys.exit(1)
-
-    return decorated
-
-
-def generate_config(quiet=False) -> None:
+def generate_config(config_path: str) -> None:
     """ Create an example Nimbo config in the project root """
 
-    if os.path.isfile(CONFIG.nimbo_config_file):
+    if os.path.isfile(config_path):
         should_overwrite = click.confirm(
-            f"{CONFIG.nimbo_config_file} already exists, do you want to overwrite it?"
+            f"{config_path} already exists, do you want to overwrite it?"
         )
         if not should_overwrite:
             print("Leaving Nimbo config intact")
             return
 
-    with open(CONFIG.nimbo_config_file, "w") as f:
+    with open(config_path, "w") as f:
         f.write(NIMBO_DEFAULT_CONFIG)
 
-    if not quiet:
-        print(f"Example config written to {CONFIG.nimbo_config_file}")
+    print(f"Example config written to {config_path}")

--- a/src/nimbo/main.py
+++ b/src/nimbo/main.py
@@ -1,36 +1,59 @@
+import os
+
 import click
 
+from nimbo import assert_required_config, set_config, cloud_context, IS_TEST_ENV
+from nimbo.core.click_extensions import (
+    HelpSection,
+    NimboCommand,
+    NimboGroup,
+    pprint_errors,
+)
 from nimbo.core import utils
-from nimbo.core.click_extensions import HelpSection, NimboCommand, NimboGroup
-from nimbo.core.cloud_provider import Cloud
-from nimbo.core.config import RequiredCase
+from nimbo.core.config import RequiredCase, make_config
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=90)
+_CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=90)
+_CONFIG_PATH_OVERRIDE = (
+    os.environ["NIMBO_CONFIG"] if "NIMBO_CONFIG" in os.environ else "nimbo-config.yml"
+)
 
 
-@click.group(cls=NimboGroup, context_settings=CONTEXT_SETTINGS)
-def cli():
+@click.group(cls=NimboGroup, context_settings=_CONTEXT_SETTINGS)
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(),
+    default=_CONFIG_PATH_OVERRIDE,
+    show_default=True,
+)
+def cli(config):
     """
     Run compute jobs on AWS as if you were running them locally.
 
     Visit https://docs.nimbo.sh for more help.
     """
-    pass
+
+    if not IS_TEST_ENV:
+        global _CONFIG_PATH_OVERRIDE
+        _CONFIG_PATH_OVERRIDE = config
+
+        set_config(config_factory=make_config, config_path=config)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("job_cmd")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.JOB)
-@utils.handle_errors
-def run(job_cmd, dry_run):
+@assert_required_config(RequiredCase.JOB)
+@pprint_errors
+@cloud_context
+def run(cloud, job_cmd, dry_run):
     """Run JOB_CMD on an instance.
 
     JOB_CMD is any command you would run locally.
     E.g. \"python runner.py --epochs=10\".\n
     The command must be between quotes.
     """
-    Cloud.run(job_cmd, dry_run)
+    cloud.run(job_cmd, dry_run)
 
 
 @cli.command(
@@ -39,9 +62,10 @@ def run(job_cmd, dry_run):
     short_help="Launch Jupiter with your code, data, and environment",
 )
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.JOB)
-@utils.handle_errors
-def notebook(dry_run):
+@assert_required_config(RequiredCase.JOB)
+@pprint_errors
+@cloud_context
+def notebook(cloud, dry_run):
     """
     Launch Jupyter Lab on an instance with your code, data and environment.
 
@@ -49,7 +73,7 @@ def notebook(dry_run):
     the notebook to your local folder, as the remote notebooks will be lost
     once the instance is terminated.
     """
-    Cloud.run("_nimbo_notebook", dry_run)
+    cloud.run("_nimbo_notebook", dry_run)
 
 
 @cli.command(
@@ -58,109 +82,119 @@ def notebook(dry_run):
     short_help="Launch an instance with minimal setup.",
 )
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.JOB)
-@utils.handle_errors
-def launch(dry_run):
+@assert_required_config(RequiredCase.JOB)
+@pprint_errors
+@cloud_context
+def launch(cloud, dry_run):
     """
     Launch an instance according to your Nimbo config with minimal setup.
 
     The launched instance does not include your code, data, or environment.
     """
-    Cloud.run("_nimbo_launch", dry_run)
+    cloud.run("_nimbo_launch", dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.JOB)
-@utils.handle_errors
-def launch_and_setup(dry_run):
+@assert_required_config(RequiredCase.JOB)
+@pprint_errors
+@cloud_context
+def launch_and_setup(cloud, dry_run):
     """
     Launch an instance with your code, data and environment.
 
     The launched instance does not run any job.
     """
-    Cloud.run("_nimbo_launch_and_setup", dry_run)
+    cloud.run("_nimbo_launch_and_setup", dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("instance_id")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.INSTANCE)
-@utils.handle_errors
-def ssh(instance_id, dry_run):
+@assert_required_config(RequiredCase.INSTANCE)
+@pprint_errors
+@cloud_context
+def ssh(cloud, instance_id, dry_run):
     """SSH into an instance by INSTANCE_ID."""
-    Cloud.ssh(instance_id, dry_run)
+    cloud.ssh(instance_id, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("instance_id")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def get_status(instance_id, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def get_status(cloud, instance_id, dry_run):
     """Get the status of an instance by INSTANCE_ID."""
-    print(Cloud.get_status(instance_id, dry_run))
+    print(cloud.get_status(instance_id, dry_run))
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def ls_active(dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def ls_active(cloud, dry_run):
     """List all your active instances."""
-    Cloud.ls_active_instances(dry_run)
+    cloud.ls_active_instances(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def ls_stopped(dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def ls_stopped(cloud, dry_run):
     """List all your stopped instances."""
-    Cloud.ls_stopped_instances(dry_run)
+    cloud.ls_stopped_instances(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("instance_id")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def rm_instance(instance_id, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def rm_instance(cloud, instance_id, dry_run):
     """Terminate an instance by INSTANCE_ID."""
-    Cloud.delete_instance(instance_id, dry_run)
+    cloud.delete_instance(instance_id, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def rm_all_instances(dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def rm_all_instances(cloud, dry_run):
     """Terminate all your instances."""
     click.confirm(
         "This will delete all your running instances.\n" "Do you want to continue?",
         abort=True,
     )
-    Cloud.delete_all_instances(dry_run)
+    cloud.delete_all_instances(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("instance_id")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def stop_instance(instance_id, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def stop_instance(cloud, instance_id, dry_run):
     """Stop an instance by INSTANCE_ID."""
-    Cloud.stop_instance(instance_id, dry_run)
+    cloud.stop_instance(instance_id, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.INSTANCE)
 @click.argument("instance_id")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def resume_instance(instance_id, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def resume_instance(cloud, instance_id, dry_run):
     """Resume a stopped instance by INSTANCE_ID."""
-    Cloud.resume_instance(instance_id, dry_run)
+    cloud.resume_instance(instance_id, dry_run)
 
 
 @cli.command(
@@ -170,40 +204,43 @@ def resume_instance(instance_id, dry_run):
 )
 @click.argument("security_group")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def add_current_ip(security_group, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def add_current_ip(cloud, security_group, dry_run):
     """Add the IP of the current machine to the allowed inbound rules of GROUP.
 
     GROUP is the security group to which the inbound rule will be added.
     """
-    Cloud.allow_ingress_current_ip(security_group, dry_run)
+    cloud.allow_ingress_current_ip(security_group, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.STORAGE)
 @click.argument("bucket_name")
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def mk_bucket(bucket_name, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def mk_bucket(cloud, bucket_name, dry_run):
     """
     Create the bucket BUCKET_NAME in S3.
 
     BUCKET_NAME is the name of the bucket to create, s3://BUCKET_NAME
     """
-    Cloud.mk_bucket(bucket_name, dry_run)
+    cloud.mk_bucket(bucket_name, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.STORAGE)
 @click.argument("path")
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def ls_bucket(path):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def ls_bucket(cloud, path):
     """List S3 objects in PATH.
 
     PATH is an S3 path of the form s3://bucket-name/my/files/path.
     """
-    Cloud.ls_bucket(path)
+    cloud.ls_bucket(path)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.STORAGE)
@@ -218,9 +255,10 @@ def ls_bucket(path):
       but don't exist in the remote folder.
     """,
 )
-@utils.assert_required_config(RequiredCase.STORAGE)
-@utils.handle_errors
-def push(folder, delete):
+@assert_required_config(RequiredCase.STORAGE)
+@pprint_errors
+@cloud_context
+def push(cloud, folder, delete):
     """Push your local datasets/results folder onto S3."""
 
     if delete:
@@ -230,7 +268,7 @@ def push(folder, delete):
             "Do you want to continue?",
             abort=True,
         )
-    Cloud.push(folder, delete)
+    cloud.push(folder, delete)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.STORAGE)
@@ -245,9 +283,10 @@ def push(folder, delete):
       folder but don't exist in the remote folder.
     """,
 )
-@utils.assert_required_config(RequiredCase.STORAGE)
-@utils.handle_errors
-def pull(folder, delete):
+@assert_required_config(RequiredCase.STORAGE)
+@pprint_errors
+@cloud_context
+def pull(cloud, folder, delete):
     """Pull datasets/results folder into your computer from S3."""
 
     if delete:
@@ -257,14 +296,15 @@ def pull(folder, delete):
             "Do you want to continue?",
             abort=True,
         )
-    Cloud.pull(folder, delete)
+    cloud.pull(folder, delete)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.STORAGE)
 @click.argument("instance_id")
-@utils.assert_required_config(RequiredCase.INSTANCE)
-@utils.handle_errors
-def sync_notebooks(instance_id):
+@assert_required_config(RequiredCase.INSTANCE)
+@pprint_errors
+@cloud_context
+def sync_notebooks(cloud, instance_id):
     """
     Pull ipynb files from INSTANCE_ID to your local folder.
 
@@ -272,62 +312,67 @@ def sync_notebooks(instance_id):
     to your local folder, as the remote notebooks will be lost once the instance
     is terminated.
     """
-    Cloud.sync_notebooks(instance_id)
+    cloud.sync_notebooks(instance_id)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
-@utils.assert_required_config(RequiredCase.NONE)
-@utils.handle_errors
+@assert_required_config(RequiredCase.NONE)
+@pprint_errors
 def generate_config():
-    """Create a base nimbo-config.yml in the current directory.
+    """Create a base configuration file in the current directory.
 
     Remember to change any fields to your own values.
     """
-    utils.generate_config()
+    utils.generate_config(_CONFIG_PATH_OVERRIDE)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def mk_instance_key():
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def mk_instance_key(cloud):
     """Create and download an instance key to the current directory."""
-    Cloud.mk_instance_key()
+    cloud.mk_instance_key()
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.INSTANCE, RequiredCase.STORAGE)
-@utils.handle_errors
-def test_access(dry_run):
+@assert_required_config(RequiredCase.INSTANCE, RequiredCase.STORAGE)
+@pprint_errors
+@cloud_context
+def test_access(cloud, dry_run):
     """Run a mock job to test your config."""
-    Cloud.run_access_test(dry_run)
+    cloud.run_access_test(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def ls_prices(dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def ls_prices(cloud, dry_run):
     """List the prices, types, and specs of GPU instances."""
-    Cloud.ls_gpu_prices(dry_run)
+    cloud.ls_gpu_prices(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def ls_spot_prices(dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def ls_spot_prices(cloud, dry_run):
     """List the prices, types, and specs of GPU spot instances."""
-    Cloud.ls_spot_gpu_prices(dry_run)
+    cloud.ls_spot_gpu_prices(dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.UTILS)
 @click.argument("qty", type=int, required=True)
 @click.argument("timescale", type=click.Choice(["days", "months"]), required=True)
 @click.option("--dry-run", is_flag=True)
-@utils.assert_required_config(RequiredCase.MINIMAL)
-@utils.handle_errors
-def spending(qty, timescale, dry_run):
+@assert_required_config(RequiredCase.MINIMAL)
+@pprint_errors
+@cloud_context
+def spending(cloud, qty, timescale, dry_run):
     """Show daily/monthly spending summary. Costs without credits or refunds applied.
 
     QTY is the number of days/months you want to see, starting from the current date.\n
@@ -335,7 +380,7 @@ def spending(qty, timescale, dry_run):
         'nimbo spending 10 days' shows daily spending of the last 10 days\n
         'nimbo spending 3 months' shows the monthly spending of the last 3 months
     """
-    Cloud.spending(qty, timescale, dry_run)
+    cloud.spending(qty, timescale, dry_run)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.ADMIN)
@@ -343,9 +388,10 @@ def spending(qty, timescale, dry_run):
 @click.option(
     "--no-s3-access", help="Create your own S3 access role separately.", is_flag=True
 )
-@utils.assert_required_config(RequiredCase.NONE)
-@utils.handle_errors
-def admin_setup(profile, no_s3_access):
+@assert_required_config(RequiredCase.NONE)
+@pprint_errors
+@cloud_context
+def admin_setup(cloud, profile, no_s3_access):
     """
     Setup Nimbo access role for your organisation.
 
@@ -355,19 +401,20 @@ def admin_setup(profile, no_s3_access):
 
     PROFILE is the profile name of your root/admin account from ~/.aws/credentials
     """
-    Cloud.setup(profile, no_s3_access)
+    cloud.setup(profile, no_s3_access)
 
 
 @cli.command(cls=NimboCommand, help_section=HelpSection.ADMIN)
 @click.argument("profile")
 @click.argument("username")
-@utils.assert_required_config(RequiredCase.NONE)
-@utils.handle_errors
-def add_user(profile, username):
+@assert_required_config(RequiredCase.NONE)
+@pprint_errors
+@cloud_context
+def add_user(cloud, profile, username):
     """Adds user USERNAME to the user group NimboUserGroup.
 
     You must have run 'nimbo admin-setup' before adding users.
 
     PROFILE is the profile name of your root/admin account from ~/.aws/credentials
     """
-    Cloud.add_user(profile, username)
+    cloud.add_user(profile, username)

--- a/src/nimbo/tests/aws/config.py
+++ b/src/nimbo/tests/aws/config.py
@@ -14,7 +14,6 @@ from nimbo.core.config import (
     yaml_loader,
 )
 
-NIMBO_CONFIG_FILE = "nimbo-config.yml"
 CONDA_ENV = "env.yml"
 ASSETS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
@@ -56,7 +55,6 @@ class CommonTestConfigMixin(abc.ABC, pydantic.BaseModel):
 
 class AwsTestConfig(CommonTestConfigMixin, AwsConfig):
     _initial_state: Dict[str, Any] = pydantic.PrivateAttr(default_factory=dict)
-    _nimbo_config_file_exists: bool = pydantic.PrivateAttr(default=True)
 
     def inject_required_config(self, *cases: RequiredCase) -> None:
         cases = RequiredCase.decompose(*cases)
@@ -88,14 +86,15 @@ class AwsTestConfig(CommonTestConfigMixin, AwsConfig):
 
 class GcpTestConfig(CommonTestConfigMixin, GcpConfig):
     _initial_state: Dict[str, Any] = pydantic.PrivateAttr(default_factory=dict)
-    _nimbo_config_file_exists: bool = pydantic.PrivateAttr(default=True)
 
     def inject_required_config(self, *cases: RequiredCase) -> None:
         pass
 
 
-def make_config() -> Union[AwsTestConfig, GcpTestConfig]:
-    raw_config = yaml_loader.from_file(os.path.join(ASSETS_PATH, NIMBO_CONFIG_FILE))
+def make_config(config_path: str) -> Union[AwsTestConfig, GcpTestConfig]:
+    raw_config = yaml_loader.from_file(os.path.join(ASSETS_PATH, config_path))
+    raw_config["config_path"] = config_path
+
     cloud_provider = CloudProvider(raw_config["cloud_provider"].upper())
 
     if cloud_provider == CloudProvider.AWS:

--- a/src/nimbo/tests/aws/test_cli.py
+++ b/src/nimbo/tests/aws/test_cli.py
@@ -77,7 +77,9 @@ def test_instance_actions(runner: CliRunner):
 
     try:
         runner.invoke(
-            cli, "stop-instance i-0be1989edd819b442 --dry-run", catch_exceptions=False,
+            cli,
+            "stop-instance i-0be1989edd819b442 --dry-run",
+            catch_exceptions=False,
         )
     except ClientError as e:
         if "InvalidInstanceID.NotFound" not in str(e):

--- a/src/nimbo/tests/aws/test_execute.py
+++ b/src/nimbo/tests/aws/test_execute.py
@@ -26,15 +26,11 @@ def test_test_access(runner: CliRunner):
 
 @isolated_filesystem(RequiredCase.JOB)
 def test_run_no_code(runner: CliRunner):
-    result = runner.invoke(
-        cli, "rm-all-instances", input="y", catch_exceptions=False
-    )
+    result = runner.invoke(cli, "rm-all-instances", input="y", catch_exceptions=False)
     assert result.exit_code == 0
     result = runner.invoke(cli, "run 'python --version'", catch_exceptions=False)
     assert result.exit_code == 0
-    result = runner.invoke(
-        cli, "rm-all-instances", input="y", catch_exceptions=False
-    )
+    result = runner.invoke(cli, "rm-all-instances", input="y", catch_exceptions=False)
     assert result.exit_code == 0
 
 
@@ -73,9 +69,7 @@ def test_spot_launch(runner: CliRunner):
     assert response["message"] == "_nimbo_launch_success"
     instance_id = response["instance_id"]
 
-    result = runner.invoke(
-        cli, f"rm-instance {instance_id}", catch_exceptions=False
-    )
+    result = runner.invoke(cli, f"rm-instance {instance_id}", catch_exceptions=False)
     assert result.exit_code == 0
 
 
@@ -87,7 +81,5 @@ def test_notebook(runner: CliRunner):
     assert response["message"] == "_nimbo_notebook_success"
     instance_id = response["instance_id"]
 
-    result = runner.invoke(
-        cli, f"rm-instance {instance_id}", catch_exceptions=False
-    )
+    result = runner.invoke(cli, f"rm-instance {instance_id}", catch_exceptions=False)
     assert result.exit_code == 0

--- a/src/nimbo/tests/aws/utils.py
+++ b/src/nimbo/tests/aws/utils.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from nimbo import CONFIG
 from nimbo.core.config import RequiredCase
-from nimbo.tests.aws.config import ASSETS_PATH, CONDA_ENV, NIMBO_CONFIG_FILE
+from nimbo.tests.aws.config import ASSETS_PATH, CONDA_ENV
 
 
 def make_file(path: str, text: str) -> None:
@@ -77,7 +77,7 @@ def _copy_assets(*assets: AssetType) -> None:
     dst = os.getcwd()
 
     if AssetType.NIMBO_CONFIG in assets:
-        src = os.path.join(ASSETS_PATH, NIMBO_CONFIG_FILE)
+        src = os.path.join(ASSETS_PATH, CONFIG.config_path)
         shutil.copy(src, dst)
     if AssetType.INSTANCE_KEYS in assets:
         keys = [file for file in os.listdir(ASSETS_PATH) if file[-4:] == ".pem"]


### PR DESCRIPTION
Allow to specify config file via CLI option or env var, solves - https://github.com/nimbo-sh/nimbo/issues/34

Big changeset due to me having to refactor `CONFIG` and `Cloud` abstraction creation and resolve some cyclical imports caused by my changes.

All tests are passing.

After merge docs will need to be updated to mention the fact that Nimbo config path can be set via `NIMBO_CONFIG` environment variable.