### PR TITLE
Allow for project name and client in config to itemise nimbo spending…

### DIFF
--- a/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_instance.py
+++ b/src/nimbo/core/cloud_provider/provider_impl/aws/services/aws_instance.py
@@ -278,11 +278,15 @@ class AwsInstance(Instance):
 
     @staticmethod
     def _make_instance_tags() -> List[Dict[str, str]]:
-        return [
+        instance_tags = [
             {"Key": "CreatedBy", "Value": "nimbo"},
             {"Key": "Owner", "Value": CONFIG.user_id},
         ]
-
+        if CONFIG.client_name is not None:
+            instance_tags.append({"Key": "Client", "Value": CONFIG.client_name})
+        if CONFIG.project_name is not None:
+            instance_tags.append({"Key": "Project", "Value": CONFIG.project_name})
+        return instance_tags
     @staticmethod
     def _make_instance_filters() -> List[Dict[str, Union[str, List[str]]]]:
         tags = AwsInstance._make_instance_tags()

--- a/src/nimbo/core/config/aws_config.py
+++ b/src/nimbo/core/config/aws_config.py
@@ -45,6 +45,8 @@ class AwsConfig(BaseConfig):
     security_group: Optional[str] = None
     instance_key: Optional[str] = None
     role: Optional[str] = None
+    project_name: Optional[str] = None
+    client_name: Optional[str] = None
 
     # The following are defined internally
     user_arn: Optional[str] = None
@@ -90,6 +92,9 @@ class AwsConfig(BaseConfig):
             required_config["instance_key"] = self.instance_key
             required_config["security_group"] = self.security_group
             required_config["role"] = self.role
+            required_config["project_name"] = self.project_name
+            required_config["client_name"] = self.client_name
+
         if RequiredCase.JOB in cases:
             required_config["conda_env"] = self.conda_env
 

--- a/src/nimbo/core/config/aws_config.py
+++ b/src/nimbo/core/config/aws_config.py
@@ -92,9 +92,7 @@ class AwsConfig(BaseConfig):
             required_config["instance_key"] = self.instance_key
             required_config["security_group"] = self.security_group
             required_config["role"] = self.role
-            required_config["project_name"] = self.project_name
-            required_config["client_name"] = self.client_name
-
+            
         if RequiredCase.JOB in cases:
             required_config["conda_env"] = self.conda_env
 


### PR DESCRIPTION
Allow for project name and client in config to itemise 'nimbo spending' by project/client not account number. This is probably very specific to our use case (as we cannot filter by {'createdBy': 'Nimbo'}, and we have many users on one AWS account number), but created the merge in case it was felt this could be useful for others. It would change the config file to looking like this screenshot, but it's setup in a way that it works as normal with project name or client being in there.
![Screenshot from 2021-10-08 11-53-52](https://user-images.githubusercontent.com/92156705/136544744-510f5b21-9e8d-4ba3-9fc9-ddf4df3edeb1.png)
